### PR TITLE
upgrade: use latest gems to avoid vulnerability in Nokogiri

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,13 +3,13 @@ GEM
   specs:
     addressable (2.5.2)
       public_suffix (>= 2.0.2, < 4.0)
-    httparty (0.15.6)
+    httparty (0.16.2)
       multi_xml (>= 0.5.2)
     mini_portile2 (2.3.0)
     multi_xml (0.6.0)
-    nokogiri (1.8.1)
+    nokogiri (1.8.2)
       mini_portile2 (~> 2.3.0)
-    public_suffix (3.0.0)
+    public_suffix (3.0.2)
 
 PLATFORMS
   ruby
@@ -20,4 +20,4 @@ DEPENDENCIES
   nokogiri!
 
 BUNDLED WITH
-   1.16.0.pre.2
+   1.16.1


### PR DESCRIPTION
The risk is minimal with this app, but it is good practice to have
up to date dependencies :)