### PR TITLE
Ensure we are using a recent version of Nokorigi

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,5 +2,5 @@
 source 'https://rubygems.org' do
   gem 'addressable' # Replacement for standard ruby URI implementation, conforms slightly better to RFCs and international URIs
   gem 'httparty'
-  gem 'nokogiri'
+  gem 'nokogiri', '~> 1.8.1'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -17,7 +17,7 @@ PLATFORMS
 DEPENDENCIES
   addressable!
   httparty!
-  nokogiri!
+  nokogiri (~> 1.8.1)!
 
 BUNDLED WITH
-   1.16.1
+   1.16.2

--- a/chronopost_fuel_multiplier.gemspec
+++ b/chronopost_fuel_multiplier.gemspec
@@ -1,19 +1,19 @@
 Gem::Specification.new do |s|
   s.name        = 'chronopost_fuel_multiplier'
-  s.version     = '0.1.1'
-  s.date        = '2017-03-08'
+  s.version     = '0.1.2'
+  s.date        = '2017-06-12'
   s.summary     = 'Retrieve current month\'s Chronopost\'s fuel surcharges'
   s.description = 'A simple gem to ease/automate getting this data every month.'
   s.authors     = ['Bob Maerten', 'Clément Joubert']
   s.files       = Dir['lib/*.rb'] + Dir['bin/*']
-  s.email       = ['bob.maerten@gmail.com', 'clement.joubert@gmail.com']
+  s.email       = ['bob@levups.com', 'clement@levups.com']
   s.homepage    = 'https://rubygems.org/gems/chronopost_fuel_multiplier'
   s.license     = 'MIT'
 
   s.bindir      = 'bin'
   s.executables = 'chronopost_fuel_multiplier'
 
-  s.add_runtime_dependency 'addressable', '~> 2.5.0'
-  s.add_runtime_dependency 'httparty',    '~> 0.14.0'
-  s.add_runtime_dependency 'nokogiri',    '~> 1.7.0.1'
+  s.add_runtime_dependency 'addressable', '~> 2.5'
+  s.add_runtime_dependency 'httparty',    '~> 0.16'
+  s.add_runtime_dependency 'nokogiri',    '~> 1.8'
 end


### PR DESCRIPTION
Dependabot will update it regularly, too.